### PR TITLE
fix: handle removes in commit

### DIFF
--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -269,6 +269,17 @@ impl Commit {
         let mut remove_atoms: Vec<Atom> = Vec::new();
         let mut add_atoms: Vec<Atom> = Vec::new();
 
+        if let Some(remove) = self.remove.clone() {
+            for prop in remove.iter() {
+                resource.remove_propval(prop);
+
+                if update_index {
+                    let val = resource.get(prop)?;
+                    let atom = Atom::new(resource.get_subject().clone(), prop.into(), val.clone());
+                    remove_atoms.push(atom);
+                }
+            }
+        }
         if let Some(set) = self.set.clone() {
             for (prop, new_val) in set.iter() {
                 resource


### PR DESCRIPTION
e449e83cb67ca4347627d1e5953145d22e8bfa66 has (accidentally?) removed handling of `remove` field on commits, so removing properties no longer works.

This PR restores it.

Tested it locally with my client code.

PR Checklist:

- [ ] Link to related issue
- [ ] Add changelog entry linking to issue
- [ ] Added tests (if needed)
- [ ] (If new feature) added in description / readme
