### PR TITLE
fix: run rustfmt

### DIFF
--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -275,7 +275,8 @@ impl Commit {
 
                 if update_index {
                     if let Ok(val) = resource_unedited.get(prop) {
-                        let atom = Atom::new(resource.get_subject().clone(), prop.into(), val.clone());
+                        let atom =
+                            Atom::new(resource.get_subject().clone(), prop.into(), val.clone());
                         remove_atoms.push(atom);
                     } else {
                         // The property does not exist, so nothing to remove.


### PR DESCRIPTION
Run rustfmt.

I also took a look at failing e2e tests—it seems that they are failing because of changes to atomicdata.dev: changing title from `atomicdata.dev` to `Atomic Data ` and removing `demo invite` from the sidebar.

PR Checklist:

- [ ] Link to related issue
- [ ] Add changelog entry linking to issue
- [ ] Added tests (if needed)
- [ ] (If new feature) added in description / readme
