### PR TITLE
fix property-scoped search

### DIFF
--- a/server/src/handlers/search.rs
+++ b/server/src/handlers/search.rs
@@ -78,7 +78,7 @@ pub async fn search_query(
                 ],
             );
             let full_query = if let Some(prop) = &params.property {
-                format!("{}:{}", prop, &q)
+                format!("property:{:?} AND {}", prop, &q)
             } else {
                 q
             };


### PR DESCRIPTION
All property-scoped searches failed with `Error parsing query Syntax Error`.
This happened because the following code

   ```rust
   let full_query = if let Some(prop) = &params.property {
       format!("property:{:?} AND {}", prop, &q)
   } else {
       q
   };
   ```

would produce a query like: `https://atomicdata.dev/properties/name:hello`

and this likely fails to parse because of multiple `:` in a string.

You can test this with the following link:
https://atomicdata.dev/search?q=hello&property=https%3A%2F%2Fatomicdata.dev%2Fproperties%2Fname

I am not sure how this was supposed to work, but I intuited my way to add property:"property-name" to query and AND-combine that with user's query.

```rust
format!("property:{:?} AND {}", prop, &q)
```

I could probably scope user's query to value:
```rust
format!("property:{:?} AND value:{}", prop, &q)
```
but I decided not to do this, so that the user can query by subject, too.

---
PR Checklist:

- [ ] Link to related issue
- [ ] Add changelog entry linking to issue
- [ ] Added tests (if needed)
- [ ] (If new feature) added in description / readme
