### PR TITLE
fix: disable previous commit validation for real

### DIFF
--- a/server/src/handlers/commit.rs
+++ b/server/src/handlers/commit.rs
@@ -25,7 +25,8 @@ pub async fn post_commit(
         validate_signature: true,
         validate_timestamp: true,
         validate_rights: true,
-        validate_previous_commit: true,
+        // https://github.com/atomicdata-dev/atomic-data-rust/issues/412
+        validate_previous_commit: false,
         update_index: true,
     };
     let commit_response = incoming_commit.apply_opts(store, &opts)?;


### PR DESCRIPTION
1c25aed4a769d7760780f59626872b6fb752d44a disabled it for library, but not the server.

PR Checklist:

- [ ] Link to related issue
- [ ] Add changelog entry linking to issue
- [ ] Added tests (if needed)
- [ ] (If new feature) added in description / readme
